### PR TITLE
Remove unnecessary Documenter dependency.

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -6,7 +6,6 @@ Distances
 DistributedArrays
 StatsBase
 MultivariateStats
-Documenter
 # New requirements for 0.7, andreasnoack says they're "special" and shouldn't be included.
 # Random
 # Statistics


### PR DESCRIPTION
Hi, as you may know we are working on a breaking release of Documenter. Therefore, we are putting upperbounds on the packages that have Documenter as a direct dependency (https://github.com/JuliaLang/METADATA.jl/pull/19162) but I noticed that this package have a dependency on Documenter for no reason. This PR removes that.